### PR TITLE
Add rel=me to twitter and mastodon

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -79,6 +79,7 @@
               type="external"
               target="_blank"
               look="link--white"
+              rel="me"
             >
               <template v-slot:image>
                 <img
@@ -96,6 +97,7 @@
               type="external"
               target="_blank"
               look="link--white"
+              rel="me"
             >
               <template v-slot:image>
                 <img
@@ -113,6 +115,7 @@
               type="external"
               target="_blank"
               look="link--white"
+              rel="me"
             >
               <template v-slot:image>
                 <img


### PR DESCRIPTION
This PR adds [rel="me"](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/me) attribute to the Twitter and Mastodon links in the footer. This verifies the link on Mastodon, and allows web extensions like [Streetpass](https://streetpass.social/) to find the profile.