### PR TITLE
Fix Mastodon domain verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
   </head>
   <body>
     <div id="app"></div>
+    <a href="https://mapstodon.space/@panoramax" rel="me" style="display:none;">Verify on Mastodon</a>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -20,9 +20,9 @@
       content="Panoramax fédère les initiatives (des collectivités, des contributeurs OSM, de l’IGN...) pour favoriser l'émergence d'un géocommun de bases de vues immersives."
     />
   </head>
+  <link href="https://mapstodon.space/@panoramax" rel="me">
   <body>
     <div id="app"></div>
-    <a href="https://mapstodon.space/@panoramax" rel="me" style="display:none;">Verify on Mastodon</a>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
       name="og:description"
       content="Panoramax fédère les initiatives (des collectivités, des contributeurs OSM, de l’IGN...) pour favoriser l'émergence d'un géocommun de bases de vues immersives."
     />
+    <link href="https://mapstodon.space/@panoramax" rel="me">
   </head>
-  <link href="https://mapstodon.space/@panoramax" rel="me">
   <body>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>


### PR DESCRIPTION
Currently the 'me' rel was added in the footer vue file but that currently doesn't result in the domain being properly verified on the Mastodon profile. I ASSUME that this is because the Mastodon parser isn't running JS so can't see the tag. This change (I think?) should make it so that no JS needs to be parsed for it to read the tag, so verification should work.

Currently it's not verified:
![image](https://github.com/panoramax-project/panoramax-website/assets/1010226/a89e0e1e-ceb0-4446-b63e-ef9523cb8501)
